### PR TITLE
Add Windows setup instructions for running without Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,40 @@
  
 ## Thank you
   Thanks to [Sayan Mondal](https://www.github.com/sayanmondal2098) and I really appreciate all kinds of feedback. Thanks for using and supporting this project!
+
+## Ejecutar en otra PC Windows sin Codex
+
+Este proyecto no necesita la app de Codex para ejecutarse en una PC Windows nueva. Puedes copiar o descargar el proyecto terminado y correrlo directamente con Python.
+
+### 1. Instalar requisitos en la nueva PC
+
+1. Instala Python 3 desde <https://www.python.org/downloads/>.
+2. Durante la instalación, marca la opción **Add Python to PATH**.
+3. Abre PowerShell en la carpeta del proyecto.
+4. Instala las dependencias:
+
+```powershell
+python -m pip install -r requirements.txt
+```
+
+> Nota: si `PyAudio` falla al instalarse, instala primero `pipwin` y luego PyAudio:
+>
+> ```powershell
+> python -m pip install pipwin
+> pipwin install pyaudio
+> ```
+
+### 2. Abrir Voice Notepad
+
+En PowerShell, entra a la carpeta `Windows` del proyecto y ejecuta la app:
+
+```powershell
+cd Windows
+python voicenote.py
+```
+
+### 3. Diferencia con una app web
+
+Los comandos `npm install`, `npm run dev`, `npm run build` y `npm run preview` solo aplican a proyectos web de Node/Vite. Este repositorio es una app de escritorio en Python con interfaz Tkinter, por eso se abre como ventana local en Windows y no desde una URL del navegador.
+
+Si quieres usarla en otra PC, debes copiar el proyecto a esa PC e instalar Python y las dependencias allí. `localhost` o una IP como `http://192.168.x.x:4173/` no aplican para esta app de escritorio.


### PR DESCRIPTION
### Motivation

- Clarify how to run this project on another Windows PC without the Codex app because the repository is a desktop Python/Tkinter application, not a web app served via Vite. 
- Provide a simple, reliable path for users who hit `PyAudio` installation issues by giving an alternative to install with `pipwin`.

### Description

- Added a new Spanish section to `README.md` titled `Ejecutar en otra PC Windows sin Codex` that explains the workflow to copy/download the project and run it locally. 
- Documented dependency installation using `python -m pip install -r requirements.txt` and a fallback sequence `python -m pip install pipwin` followed by `pipwin install pyaudio` for Windows `PyAudio` problems. 
- Added the exact launch steps `cd Windows` and `python voicenote.py` to start the Tkinter app. 
- Clarified that `npm install`, `npm run dev`, `npm run build`, `npm run preview`, `localhost` and IP-based browser URLs do not apply to this desktop app. 

### Testing

- Successfully ran `python -m py_compile Windows/voicenote.py Linux/voicenote.py` to verify the Python files compile without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35985bf730833187482826dc1502a7)